### PR TITLE
Add nnoir and nnoir-chainer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ h5py
 scikit-image
 xmltodict
 git+https://github.com/yasuyuky/chainer-ya-utils
+nnoir
+nnoir-chainer


### PR DESCRIPTION
Add [nnoir](https://pypi.org/project/nnoir/) and [nnoir-chainer](https://pypi.org/project/nnoir-chainer/) to the `requirements.txt` so as to be able to generate nnoirs in the same environment in which the models are trained.