### PR TITLE
Add ENV DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG CUDA_VERSION=9.2
 ARG CUDNN_VERSION=7
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Set `DEBIAN_FRONTEND` to `noninteractive` to avoid halting build because of timezone selection at `apt-get install`. 