### PR TITLE
add versioning to nnoir related packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ h5py
 scikit-image
 xmltodict
 git+https://github.com/yasuyuky/chainer-ya-utils
-nnoir
-nnoir-chainer
+nnoir==1.0.2
+nnoir-chainer==1.1.0


### PR DESCRIPTION
added versions for nnoir related packages to allow dependency checks.
also updates `nnoir-chainer` from 1.0.0 to 1.1.0